### PR TITLE
addresses chpasswd issues with standalone monitor

### DIFF
--- a/dynamite_nsm/services/elasticsearch.py
+++ b/dynamite_nsm/services/elasticsearch.py
@@ -287,8 +287,8 @@ class ElasticPasswordConfigurator:
         except HTTPError as e:
             if e.code != 200:
                 sys.stderr.write('[-] Failed to update {} password - [{}]\n'.format(user, e))
-                return False
-            return True
+            return False
+        return True
 
     def set_apm_system_password(self, new_password, stdout=False):
         """

--- a/dynamite_nsm/services/kibana.py
+++ b/dynamite_nsm/services/kibana.py
@@ -194,7 +194,6 @@ class KibanaConfigurator:
                     kibana_search_config_obj.write('{}: {}\n'.format(k, v))
 
 
-
 class KibanaInstaller:
     """
     Provides a simple interface for installing a new Kibana interface with ElastiFlow dashboards

--- a/scripts/dynamite.py
+++ b/scripts/dynamite.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
                                                password=utilities.prompt_password()):
                 sys.exit(0)
             else:
-                sys.stderr.write('[-] Failed to reset Kibana -> ElasticSearch password.\n')
+                sys.stderr.write('[-] Failed to reset Monitor password.\n')
                 sys.exit(1)
         else:
             sys.stderr.write('[-] Unrecognized component - {}\n'.format(args.component))


### PR DESCRIPTION
- addresses issue where `chpasswd monitor` failed to reset logstash & kibana passwords